### PR TITLE
add jbang catalog

### DIFF
--- a/.github/workflows/renovate.json
+++ b/.github/workflows/renovate.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["github>jbanghub/.github"]
+}   

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ See <https://blog.jabref.org/2024/04/03/JabRef5-13/#special-thanks> for real-wor
    - Linux/macOS: `curl -Ls https://sh.jbang.dev | bash -s - app setup` or
    - Windows (Powershell): `iex "& { $(iwr -useb https://ps.jbang.dev) } app setup"`
 3. Add `oauth=...` to `~/.github` with `...` being your [GitHub personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-personal-access-token-classic). See [GitHub API for Java](https://github-api.kohsuke.org/) for details.
-4. `jbang https://github.com/koppor/github-contributors-list/blob/HEAD/gcl.java --owner=<owner> --repo=<repository> --startrevision=<startCommitRevStr> --endrevision=<endCommitRevStr> <repositoryPath>`
+4. `jbang gcl@koppor/github-contributors-list --owner=<owner> --repo=<repository> --startrevision=<startCommitRevStr> --endrevision=<endCommitRevStr> <repositoryPath>`
 
 ```
 Usage: jbang gcl.java [-lhV] [--startrevision=<startCommitRevStr>]

--- a/jbang-catalog.json
+++ b/jbang-catalog.json
@@ -1,0 +1,10 @@
+{
+  "catalogs": {},
+  "aliases": {
+    "gcl": {
+      "script-ref": "gcl.java",
+      "java-agents": []
+    }
+  },
+  "templates": {}
+}


### PR DESCRIPTION
Great use of jbang :)

This pr adds a jbang-catalog.json so you can justs do `jbang gcl@koppor/github-contributors-list`.

You can also add a koppor/jbang-catalog repo instead and it would be even shorter using `jbang gcl@koppor`.

