### PR TITLE
enable renovatebot for jbang deps

### DIFF
--- a/.github/workflows/renovate.json
+++ b/.github/workflows/renovate.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["github>jbanghub/.github"]
+}   


### PR DESCRIPTION
I saw your comment on dependabot not supporting jbang dependencies. 
That is unfortunately true and there is no sign they will consider adding support for it (or any other new way of doing dependencies).

renovatebot does support it though and this PR reuses jbanghubs jbang friendly config. You can also just wholesale copy the config directly in if you want to but this way you will get improvements from jbanghub  updates.

To use this you need to enable a renovate bot on the repo. I recommend https://github.com/apps/forking-renovate as it does not require write access to your repository.


hope that helps :)